### PR TITLE
Fixed alignment issue with about divider

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -166,7 +166,8 @@
 
   .about__devider {
     font-size: 100%;
-    letter-spacing: 9.09px; }
+    letter-spacing: 9.09px;
+    text-indent: 9.09px;}
 
   .about__text {
     font-size: 100%; }


### PR DESCRIPTION
The about divider is not perfectly aligned as in here

<img width="559" alt="Captura de ecrã 2021-02-11, às 11 13 28" src="https://user-images.githubusercontent.com/6451402/107630119-02384d00-6c5b-11eb-9d40-983e147ad414.png">

According to [this stackexchange answer](https://stackoverflow.com/a/21612203/2700173), we can fix this by "indenting the text by the same amount as the letter-spacing"

After the proposed changes, the divider becomes perfectly centered
<img width="483" alt="Captura de ecrã 2021-02-11, às 11 13 55" src="https://user-images.githubusercontent.com/6451402/107630138-095f5b00-6c5b-11eb-8069-2bcd81ec60b4.png">

