### PR TITLE
Fixing incorrect date using Liquid Filters

### DIFF
--- a/_posts/2020-04-01-updated.md
+++ b/_posts/2020-04-01-updated.md
@@ -7,4 +7,4 @@ tags: [tag4, tag5]
 splash_img_source: /assets/img/traffic-332857_1920.jpg
 splash_img_caption: Representative image. Image by <a href="https://pixabay.com/users/jonbonsilver-236141/">jonbonsilver</a> on Pixabay.
 ---
-This post was originally posted on 2020-04-02 but updated on 2020-12-25 so this information is shown in the post meta.
+This post was originally posted on {{ page.date | date_to_string: "ordinal", "US" }} but updated on {{ page.updated | date_to_string: "ordinal", "US" }} so this information is shown in the post meta.


### PR DESCRIPTION
Using Jekyll Liquid Filters to retrieve both the original date and updated date (in YAML front matter), to the "This Post Was Updated" blog post's content.

Fixes incorrect date in the same blog post. It mentions that it's "Published Apr 1" but the blog content mentions "This post was originally posted on 2020-04-02", clearly this is a mistake and needs to be fixed: 

With this PR using Liquid Filters, instead of hard coded values in the blog post's content and repeating yourself, all you have to do is change the YAML front matter and THAT change is reflected in the content. 

Users can have different date formats by removing the "US" (United States) argument in the liquid filter in the markdown file.

Sources:
https://jekyllrb.com/docs/variables/
https://jekyllrb.com/docs/front-matter/
https://learn.cloudcannon.com/jekyll/date-formatting/
http://alanwsmith.com/jekyll-liquid-date-formatting-examples